### PR TITLE
Feat: Upload images into S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ out/
 .vscode/
 
 ### yaml ###
-#*.yaml
+*.yaml
 
 ### db.sqlite ###
 db.sqlite

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,16 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    // AWS S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+
+    // Marvin (이미지 리사이징)
+    implementation 'com.github.downgoon:marvin:1.5.5'
+    implementation 'com.github.downgoon:MarvinPlugins:1.5.5'
+
+    implementation 'org.springframework.boot:spring-boot-devtools'
+
 
 }
 

--- a/src/main/java/com/example/stagealarm/awsS3/CustomMultipartFile.java
+++ b/src/main/java/com/example/stagealarm/awsS3/CustomMultipartFile.java
@@ -1,0 +1,67 @@
+package com.example.stagealarm.awsS3;
+
+import org.springframework.util.Assert;
+import org.springframework.util.FileCopyUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class CustomMultipartFile implements MultipartFile {
+    private final String name;
+    private String originalFilename;
+    private String contentType;
+    private final byte[] content;
+    boolean isEmpty;
+
+    public CustomMultipartFile(String name, String originalFilename, String contentType, byte[] content) {
+        Assert.hasLength(name, "파일명 null");
+        this.name = name;
+        this.originalFilename = (originalFilename != null ? originalFilename : "");
+        this.contentType = contentType;
+        this.content = (content != null ? content : new byte[0]);
+        this.isEmpty = false;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String getOriginalFilename() {
+        return this.originalFilename;
+    }
+
+    @Override
+    public String getContentType() {
+        return this.contentType;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return (this.content.length == 0);
+    }
+
+    @Override
+    public long getSize() {
+        return this.content.length;
+    }
+
+    @Override
+    public byte[] getBytes() throws IOException {
+        return this.content;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return new ByteArrayInputStream(this.content);
+    }
+
+    @Override
+    public void transferTo(File dest) throws IOException, IllegalStateException {
+        FileCopyUtils.copy(this.content, dest);
+    }
+}

--- a/src/main/java/com/example/stagealarm/awsS3/S3FileService.java
+++ b/src/main/java/com/example/stagealarm/awsS3/S3FileService.java
@@ -1,0 +1,129 @@
+package com.example.stagealarm.awsS3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import marvin.image.MarvinImage;
+import org.marvinproject.image.transform.scale.Scale;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class S3FileService {
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Transactional
+    public List<String> uploadIntoS3(String folder, List<MultipartFile> multipartFileList) {
+        log.info("uploadIntoS3 tx start");
+        List<String> imgUrlList = new ArrayList<>();
+
+        multipartFileList.forEach(file -> {
+            if (Objects.requireNonNull(file.getContentType()).contains("image")) {
+
+                String filename = createFilename(file.getOriginalFilename());
+                String fileFormat = file.getContentType().substring(file.getContentType().lastIndexOf("/")+1);
+                log.info("fileFormat: : "+fileFormat);
+//                String fileExtension = this.getFileExtension(filename);
+                if (folder.equals("/profileImg")) {
+                    file = resizeImage(filename, fileFormat, file, 500);
+                } else if (folder.equals("/artistImg")) {
+                    file = resizeImage(filename, fileFormat, file, 750);
+                }
+
+                // 리사이징 후 S3에 업로드
+                ObjectMetadata metadata = new ObjectMetadata();
+                metadata.setContentLength(file.getSize());
+                metadata.setContentType(file.getContentType());
+                log.info("contentType: " + file.getContentType());
+
+                try (InputStream inputStream = file.getInputStream()) {
+                    amazonS3.putObject(
+                            new PutObjectRequest(bucket + folder,
+                                    filename,
+                                    inputStream,
+                                    metadata)
+                                    .withCannedAcl(CannedAccessControlList.PublicRead)
+                    );
+                    // 성공적 업로드시 imgUrlList에 추가
+                    imgUrlList.add(amazonS3.getUrl(bucket + folder, filename).toString());
+                } catch (IOException e) {
+                    log.warn(e.getMessage() + " : 이미지 업로드에 실패하였습니다. ");
+                }
+            }
+        });
+        log.info("uploadIntoS3 tx end");
+        return imgUrlList;
+    }
+
+    private String createFilename(String filename) {
+//        return UUID.randomUUID().toString();
+        return UUID.randomUUID().toString().concat(getFileExtension(filename));
+    }
+
+    private String getFileExtension(String filename) {
+        if (filename.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일입니다.");
+        }
+        return filename.substring(filename.lastIndexOf("."));
+    }
+
+    @Transactional
+    public void deleteFile(String folder, String filename) {
+        amazonS3.deleteObject(bucket+folder, filename);
+    }
+
+    @Transactional
+    public MultipartFile resizeImage(String filename, String fileFormat, MultipartFile originalFile, int targetWidth) {
+        try {
+            // MultipartFile -> BufferedImage 형태로 변환
+            BufferedImage image = ImageIO.read(originalFile.getInputStream());
+            int originWidth = image.getWidth();
+            int originHeight = image.getHeight();
+
+            if (originWidth < targetWidth) {
+                return originalFile;
+            }
+
+            MarvinImage marvinImage = new MarvinImage(image);
+
+            Scale scale = new Scale();
+            scale.load();
+            scale.setAttribute("newWidth", targetWidth);
+            scale.setAttribute("newHeight", targetWidth * originHeight / originWidth);
+            scale.process(marvinImage.clone(), marvinImage, null, null, false);
+
+            BufferedImage imageNoAlpha = marvinImage.getBufferedImageNoAlpha();
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ImageIO.write(imageNoAlpha, fileFormat, baos);
+            baos.flush();
+
+            return new CustomMultipartFile(filename, fileFormat, originalFile.getContentType(), baos.toByteArray());
+
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 리사이징에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/stagealarm/awsS3/S3ImageController.java
+++ b/src/main/java/com/example/stagealarm/awsS3/S3ImageController.java
@@ -1,0 +1,27 @@
+package com.example.stagealarm.awsS3;
+
+import com.example.stagealarm.awsS3.S3FileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class S3ImageController {
+    private final S3FileService s3FileService;
+
+    @GetMapping
+    public String hello() {
+        return "content/hello";
+    }
+
+    @PostMapping("/image")
+    public ResponseEntity<String> imgUpload(
+            @RequestBody List<MultipartFile> files) {
+        List<String> lists = s3FileService.uploadIntoS3("/boardImg", files);
+        return ResponseEntity.ok(lists.get(0));
+    }
+}

--- a/src/main/java/com/example/stagealarm/awsS3/S3ImageViewController.java
+++ b/src/main/java/com/example/stagealarm/awsS3/S3ImageViewController.java
@@ -1,0 +1,12 @@
+package com.example.stagealarm.awsS3;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class S3ImageViewController {
+    @GetMapping("/imageUpload")
+    public String imageUpload() {
+        return "content/imageUpload";
+    }
+}

--- a/src/main/java/com/example/stagealarm/board/Board.java
+++ b/src/main/java/com/example/stagealarm/board/Board.java
@@ -1,15 +1,15 @@
 package com.example.stagealarm.board;
 
 import com.example.stagealarm.BaseEntity;
+import com.example.stagealarm.image.entity.Image;
 import com.example.stagealarm.user.UserEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -27,4 +27,8 @@ public class Board  extends BaseEntity {
   private UserEntity userEntity;
   @ManyToOne(fetch = FetchType.LAZY)
   private Category category;
+
+  @OneToMany(cascade = CascadeType.ALL)
+  private List<Image> imageList;
+
 }

--- a/src/main/java/com/example/stagealarm/config/S3Config.java
+++ b/src/main/java/com/example/stagealarm/config/S3Config.java
@@ -1,0 +1,30 @@
+package com.example.stagealarm.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/example/stagealarm/image/entity/Image.java
+++ b/src/main/java/com/example/stagealarm/image/entity/Image.java
@@ -1,4 +1,4 @@
-package com.example.stagealarm.image;
+package com.example.stagealarm.image.entity;
 
 import com.example.stagealarm.BaseEntity;
 import com.example.stagealarm.board.Board;
@@ -6,10 +6,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Builder
@@ -21,5 +18,13 @@ public class Image extends BaseEntity {
   private String imgUrl;
 
   @ManyToOne(fetch = FetchType.LAZY)
+  @Setter
   private Board board;
+
+
+  // 연관관계 편의 메서드
+  public void addBoard(Board boardEntity) {
+    this.setBoard(boardEntity);
+    boardEntity.getImageList().add(this);
+  }
 }

--- a/src/main/java/com/example/stagealarm/image/repo/ImageRepository.java
+++ b/src/main/java/com/example/stagealarm/image/repo/ImageRepository.java
@@ -1,0 +1,8 @@
+package com.example.stagealarm.image.repo;
+
+import com.example.stagealarm.image.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,11 @@ spring:
     database-platform: org.hibernate.community.dialect.SQLiteDialect
     show-sql: true
 
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 100MB
+      max-request-size: 100MB
 
 jwt:
   secret: sakjhgdfksljbvdkbjkebwflkasjknvxckljw
@@ -26,3 +31,15 @@ thymeleaf:
   suffix: .html
   enabled: true
 
+cloud:
+  aws:
+    s3:
+      bucket: stage-alarm
+    credentials:
+      access-key:
+      secret-key:
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false

--- a/src/main/resources/templates/content/imageUpload.html
+++ b/src/main/resources/templates/content/imageUpload.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="ko"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/defaultLayout}"
+      layout:fragment="content">
+<head>
+    <title>main</title>
+
+    <style>
+        .image-size{
+            width: 300px;
+            height: 300px;
+        }
+    </style>
+<body>
+
+<!-- Main -->
+<main role="main" class="ml-sm-auto px-md-4" style="height: auto; min-height: 1500px; margin-bottom: 70px; display: flex; flex-direction: column;">
+    <div class="main-container border rounded p-3 mt-2" style="flex: 1;"> <!-- 메인컨텐츠 주변 보더라인 잡기-->
+        <div>
+            <form id="image" enctype="multipart/form-data">
+                <input type="file" id="fileInput" name="fileInput" multiple>
+                <button type="button" id="uploadButton">
+                   첨부하기
+                </button>
+                <div id="imageContainer" class="image-size"></div>
+            </form>
+        </div>
+        <br>
+    </div>
+</main>
+
+<script>
+
+    $('#uploadButton').click(function () {
+        var formData = new FormData();
+        var fileInput = document.getElementById('fileInput');
+        var files = fileInput.files;
+
+        for (var i = 0; i < files.length; i++) {
+            formData.append('files', files[i]);
+        }
+
+        $.ajax({
+            url: '/image',
+            type: 'POST',
+            data: formData,
+            contentType: false,
+            processData: false,
+            success: function (response) {
+                console.log("upload success");
+                var imgUrl = response;
+                $('#imageContainer').html('<img src="' + imgUrl + '" alt="Uploaded Image">');
+            },
+            error: function (xhr, status, error) {
+                console.error("upload failed");
+            },
+        });
+    });
+
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
1. application.yaml에 s3 액세스키와 시크릿키가 포함되어야 하므로 gitignore 파일로 yaml 추가
2. 일단 이미지 업로드 postmapping으로 작동하도록 구현 -> 추후 게시글 업로드, 아티스트 정보 업로드, 프로필사진 업로드 기능 구현 이후 알맞게 적용할 예정
3. 프론트 서버 재시작없이 변경 가능하도록 devtools build 추가
4. Image와 Board의 양방향 매핑과 연관관계 편의 메서드 생성